### PR TITLE
Display sys attributes in window and/or terminal of example app

### DIFF
--- a/example/oink/__main__.py
+++ b/example/oink/__main__.py
@@ -2,14 +2,24 @@ import sys
 import tkinter
 import desktop_app
 
-desktop_app.set_process_appid('oink')
+desktop_app.set_process_appid("oink")
+
 
 def main():
     root = tkinter.Tk(className=sys.argv[0])
-    root.geometry("300x300")
+    root.geometry("500x300")
     w = tkinter.Label(root, text="Oink!")
-    w.place(relx=0.5, rely=0.5, anchor=tkinter.CENTER)
+    w.place(relx=0.5, rely=0.3, anchor=tkinter.CENTER)
+    sys_info = (
+        f"sys.prefix: {sys.prefix}\n"
+        f"sys.exec_prefix: {sys.exec_prefix}\n"
+        f"sys.executable: {sys.executable}"
+    )
+    s = tkinter.Label(root, text=sys_info, justify=tkinter.LEFT)
+    s.place(relx=0.05, rely=0.5, anchor=tkinter.W)
+    print(sys_info)
     root.mainloop()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This proposal sees the following `sys` attributes in the window and/or terminal of the `oink` example:
![image](https://user-images.githubusercontent.com/5637107/81520605-20011a80-9388-11ea-803b-8142417f5c22.png)

```
sys.prefix: c:\users\rpanderson\dev\desktop-app\.venv
sys.exec_prefix: c:\users\rpanderson\dev\desktop-app\.venv
sys.executable: c:\users\rpanderson\dev\desktop-app\.venv\scripts\python.exe
```
The users can readily determine if `desktop-app` has performed as advertised/intended.