### PR TITLE
Cast Path to str in subprocess.call

### DIFF
--- a/desktop_app/launcher.py
+++ b/desktop_app/launcher.py
@@ -78,9 +78,6 @@ def entry_point():
         popen_kwargs['creationflags'] = CREATE_NO_WINDOW
 
     try:
-        print(python)
-        print(script_path)
-        print(sys.argv[1:])
         sys.exit(
             subprocess.call(
                 [str(python), str(script_path)] + sys.argv[1:], **popen_kwargs

--- a/desktop_app/launcher.py
+++ b/desktop_app/launcher.py
@@ -78,6 +78,13 @@ def entry_point():
         popen_kwargs['creationflags'] = CREATE_NO_WINDOW
 
     try:
-        sys.exit(subprocess.call([python, script_path] + sys.argv[1:], **popen_kwargs))
+        print(python)
+        print(script_path)
+        print(sys.argv[1:])
+        sys.exit(
+            subprocess.call(
+                [str(python), str(script_path)] + sys.argv[1:], **popen_kwargs
+            )
+        )
     except KeyboardInterrupt:
         sys.exit(1)


### PR DESCRIPTION
Required for Python < 3.8, which otherwise fails in `launcher.py`.
```
(base) C:\Users\rpanderson\dev>oink
Traceback (most recent call last):
  File "C:\Users\rpanderson\AppData\Local\Continuum\anaconda3\Scripts\oink-script.py", line 11, in <module>
    load_entry_point('oink', 'console_scripts', 'oink')()
  File "c:\users\rpanderson\dev\desktop-app\desktop_app\launcher.py", line 81, in entry_point
    sys.exit(subprocess.call([python, script_path] + sys.argv[1:], **popen_kwargs))
  File "C:\Users\rpanderson\AppData\Local\Continuum\anaconda3\lib\subprocess.py", line 339, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\Users\rpanderson\AppData\Local\Continuum\anaconda3\lib\subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "C:\Users\rpanderson\AppData\Local\Continuum\anaconda3\lib\subprocess.py", line 1148, in _execute_child
    args = list2cmdline(args)
  File "C:\Users\rpanderson\AppData\Local\Continuum\anaconda3\lib\subprocess.py", line 555, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: argument of type 'WindowsPath' is not iterable
```
Testing confirms this, i.e. example app does not launch successfully when shortcut is invoked: [example](https://github.com/rpanderson/desktop-app/runs/668835263?check_suite_focus=true#step:7:11).
