### PR TITLE
Fix conda build for macos target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
           - { os: ubuntu-latest,   python: '3.8',  arch: x64 }
           - { os: ubuntu-latest,   python: '3.7',  arch: x64 }
 
-          - { os: macos-latest,    python: '3.10',  arch: x64 }
-          - { os: macos-latest,    python: '3.9',  arch: x64 }
-          - { os: macos-latest,    python: '3.8',  arch: x64 }
-          - { os: macos-latest,    python: '3.7',  arch: x64 }
+          - { os: macos-10.15,    python: '3.10',  arch: x64 }
+          - { os: macos-10.15,    python: '3.9',  arch: x64 }
+          - { os: macos-10.15,    python: '3.8',  arch: x64 }
+          - { os: macos-10.15,    python: '3.7',  arch: x64 }
 
           - { os: windows-latest,  python: '3.10',  arch: x64 }
           - { os: windows-latest,  python: '3.9',  arch: x64 }


### PR DESCRIPTION
For macos target, the conda build fails due to missing xcode 11.7 in macos-latest runner images, which is relied on as workaround to allow building in the first place. With restricting the runner image to macos-10.15 the building succeeds again.