### PR TITLE
Update to properly find distribution name for PEP660 editable installs.

### DIFF
--- a/desktop_app/environment.py
+++ b/desktop_app/environment.py
@@ -141,7 +141,10 @@ def get_distribution_of_module(module_name):
         if distribution.files is None:
             continue
         for path in distribution.files:
-            if Path(path).parts[0] == base_module:
+            p = Path(path).parts[0]
+            if (p == base_module or # standard installation or pre-PEP660 editable
+                p.startswith(f'__editable__.{base_module:s}')): # PEP660 editable
+
                 return distribution.metadata['Name']
 
 


### PR DESCRIPTION
Fixes #25 

I've checked this under a number of situations and I believe it works generally.

Ultimately PEP660 editable installs no longer default to having a symlink list of files to check the module name against. Now they generate a static .pth, and if not using a src-directory layout, a dynamic .pth finder. This change checks for the default naming convention of the .pth file in both cases, which is `__editable__.base_module`.